### PR TITLE
Modify the command to test out in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In `~/nostalgia_data/videos_watched.jsonl` the data for events on HTML5 video el
 
 1. `pip install nostalgia_chrome`
 
-1. To test it out, run `nostalgia_chrome server`. This will run the web server in the foreground so you can see that it works.
+1. To test it out, run `nostalgia_chrome run_server`. This will run the web server in the foreground so you can see that it works.
 
 1. Visit a (non-file / localhost) URL so that you can verify it works. The data will be stored in `~/nostalgia_data/meta.jsonl`, `~/nostalgia_data/html`.
 


### PR DESCRIPTION
### Summary

To test it out, I thought `nostalgia_chrome run_server` would be a right command name.
"nostalgia_chrome --help" shows instructions below : 
```
COMMANDS
    COMMAND is one of the following:

     run_server
       Run nostalgia_chrome which receives pages when visiting a page in Chrome.

     backup_history
       Copies the Chrome History sqlite to a safe location

     print_version
       Prints the current version of nostalgia_chrome, and more
```